### PR TITLE
Update unit-test-security-rules/firestore.rules to be more strict

### DIFF
--- a/unit-test-security-rules/firestore.rules
+++ b/unit-test-security-rules/firestore.rules
@@ -10,7 +10,7 @@ service cloud.firestore {
       // If you create a room, you must set yourself as the owner.
       allow create: if request.resource.data.owner == request.auth.uid;
       // Only the room owner is allowed to modify it, and owner mustn't be able to assign his room to other user.
-      allow update: if resource.data.owner == request.auth.uid && (request.resource.data.owner == null || request.resource.data.owner == request.auth.uid);
+      allow update: if resource.data.owner == request.auth.uid && request.resource.data.owner == request.auth.uid;
     }
   }
 }

--- a/unit-test-security-rules/firestore.rules
+++ b/unit-test-security-rules/firestore.rules
@@ -9,8 +9,8 @@ service cloud.firestore {
       allow read;
       // If you create a room, you must set yourself as the owner.
       allow create: if request.resource.data.owner == request.auth.uid;
-      // Only the room owner is allowed to modify it.
-      allow update: if resource.data.owner == request.auth.uid;
+      // Only the room owner is allowed to modify it, and owner mustn't be able to assign his room to other user.
+      allow update: if resource.data.owner == request.auth.uid && (request.resource.data.owner == null || request.resource.data.owner == request.auth.uid);
     }
   }
 }


### PR DESCRIPTION
Shouldn't it also disallow room owner to assign his room to other user?
