### PR TITLE
Cleanup stale projectId vars

### DIFF
--- a/cs-walkthrough/functions/test_all.js
+++ b/cs-walkthrough/functions/test_all.js
@@ -14,7 +14,6 @@
 const fs = require('fs');
 const path = require("path");
 
-const FIREBASE_PROJECT_ID = "something"
 const TEST_FIREBASE_PROJECT_ID = "test-firestore-rules-project";
 
 const firebase = require("@firebase/rules-unit-testing");
@@ -37,15 +36,16 @@ after(() => {
 });
 
 describe("shopping cart creation", () => {
-  const projectId = "cart-security-tests";
-  const admin = firebase.initializeAdminApp({ projectId}).firestore();
+  const admin = firebase.initializeAdminApp({
+    projectId: TEST_FIREBASE_PROJECT_ID
+  }).firestore();
   const db = firebase.initializeTestApp({
-    projectId: projectId,
+    projectId: TEST_FIREBASE_PROJECT_ID,
     auth: aliceAuth
   }).firestore();
 
   after(() => {
-    firebase.clearFirestoreData({projectId: "emulator-codelab-dev"});
+    firebase.clearFirestoreData({projectId: TEST_FIREBASE_PROJECT_ID});
   });
 
   it('can be created by the cart owner', async () => {


### PR DESCRIPTION
* Removes unused `FIREBASE_PROJECT_ID` variable
* Changes `"shopping cart creation"` tests to use the same `TEST_FIREBASE_PROJECT_ID` that the other tests use