### PR TITLE
Update package.json

### DIFF
--- a/unit-test-security-rules-v9/package.json
+++ b/unit-test-security-rules-v9/package.json
@@ -11,8 +11,8 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@firebase/rules-unit-testing": "^2.0.1",
-    "firebase": "^9.1.0",
+    "@firebase/rules-unit-testing": "2.0.0",
+    "firebase": "9.0.2",
     "mocha": "^8.4.0"
   }
 }


### PR DESCRIPTION
Update to the correct dependencies to prevent Firebase and FirebaseFirestore type mismatch.

This will correct the error: FirebaseError: Expected first argument to collection() to be a CollectionReference, a DocumentReference or FirebaseFirestore

when trying to setup data using: 
 
```
await testEnv.withSecurityRulesDisabled(async (context) => {
      await setDoc(doc(context.firestore(), 'users/foobar'), { foo: 'bar' });
});
```