### PR TITLE
Fix command line in cloud functions readme

### DIFF
--- a/unit-test-cloud-functions/README.md
+++ b/unit-test-cloud-functions/README.md
@@ -13,5 +13,5 @@ You will also need the [Firebase CLI](https://firebase.google.com/docs/cli).
 To run the tests:
 
 ```
-firebase emulators:exec --project=fakeproject 'npm run test'
+firebase emulators:exec --project=fakeproject "npm --prefix functions run test"
 ```


### PR DESCRIPTION
'npm run test' must be executed inside functions directory