### PR TITLE
Added missing await to beforeEach

### DIFF
--- a/unit-test-security-rules-v9/test/database.spec.js
+++ b/unit-test-security-rules-v9/test/database.spec.js
@@ -51,7 +51,7 @@ after(async () => {
 });
 
 beforeEach(async () => {
-  testEnv.clearDatabase();
+  await testEnv.clearDatabase();
 });
 
 // If you want to define global variables for Rules Test Contexts to save some


### PR DESCRIPTION
In the `unit-test-security-rules-v9` part of the project in the `beforeEach` method there is an await missing, causing the npm command: `test-database` to fail.

I also have an issue with it timing out to early when running: 

```
firebase emulators:exec --only database "npm run test-database"
```

This can be fixed by replacing the npm command: `test-database` with:

```
"mocha --timeout 10000 --exit test/database.spec.js",
```

(Simply adding a longer timeout).

I've decided to only add the await in this PR, because the timeout issue doesn't happen on every machine. 