### PR TITLE
Fix floating promise in expectPermissionGetSucceeds

### DIFF
--- a/unit-test-security-rules-v9/test/utils.ts
+++ b/unit-test-security-rules-v9/test/utils.ts
@@ -59,7 +59,8 @@ export async function expectFirestorePermissionUpdateSucceeds(promise: Promise<a
 }
 
 export async function expectPermissionGetSucceeds(promise: Promise<any>) {
-  expect(assertSucceeds(promise)).not.toBeUndefined();
+  const successResult = await assertSucceeds(promise);
+  expect(successResult).not.toBeUndefined();
 }
 
 export async function expectDatabasePermissionUpdateSucceeds(promise: Promise<any>) {

--- a/unit-test-security-rules/test/utils.ts
+++ b/unit-test-security-rules/test/utils.ts
@@ -59,7 +59,8 @@ export async function expectFirestorePermissionUpdateSucceeds(promise: Promise<a
 }
 
 export async function expectPermissionGetSucceeds(promise: Promise<any>) {
-  expect(assertSucceeds(promise)).not.toBeUndefined();
+  const successResult = await assertSucceeds(promise);
+  expect(successResult).not.toBeUndefined();
 }
 
 export async function expectDatabasePermissionUpdateSucceeds(promise: Promise<any>) {


### PR DESCRIPTION
The promise returned by `assertSucceeds` is not awaited in the `expectPermissionGetSucceeds` helper function.

This may lead to misleading test results, where tests pass/fail inconsistently.

---

To keep it consistent with the pattern used in the other util functions I've assigned the awaited result of `assertSucceeds` to a const.