### PR TITLE
Fix dead-code OR expression in permission-denied assertion

### DIFF
--- a/unit-test-security-rules-v9/test/utils.ts
+++ b/unit-test-security-rules-v9/test/utils.ts
@@ -45,7 +45,7 @@ export function getDatabaseCoverageMeta(databaseName: string, firebaseJsonPath: 
 
 export async function expectFirestorePermissionDenied(promise: Promise<any>) {
   const errorResult = await assertFails(promise);
-  expect(errorResult.code).toBe('permission-denied' || 'PERMISSION_DENIED');
+  expect(errorResult.code).toBe('permission-denied');
 }
 
 export async function expectDatabasePermissionDenied(promise: Promise<any>) {

--- a/unit-test-security-rules/test/utils.ts
+++ b/unit-test-security-rules/test/utils.ts
@@ -45,7 +45,7 @@ export function getDatabaseCoverageMeta(databaseName: string, firebaseJsonPath: 
 
 export async function expectFirestorePermissionDenied(promise: Promise<any>) {
   const errorResult = await assertFails(promise);
-  expect(errorResult.code).toBe('permission-denied' || 'PERMISSION_DENIED');
+  expect(errorResult.code).toBe('permission-denied');
 }
 
 export async function expectDatabasePermissionDenied(promise: Promise<any>) {


### PR DESCRIPTION
`'permission-denied' || 'PERMISSION_DENIED'` always evaluates to the first string due to JS short-circuit; drop the unreachable alternative so the assertion matches only the actual error code.